### PR TITLE
Properly scope the css for the footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -4,7 +4,7 @@ import style from './footer.module.css';
 class Footer extends React.Component {
   render() {
     return (
-      <footer>
+      <footer className={style.footer}>
         <p>© 2016 ACME, Inc. All Rights Reserved.</p>
       </footer>
     );

--- a/src/components/footer.module.css
+++ b/src/components/footer.module.css
@@ -1,4 +1,4 @@
-footer {
+.footer {
   position: absolute;
   width: 100%;
   height: 44px;


### PR DESCRIPTION
Loading the .css files with element selectors will pollute the global scope, defeating the purpose of css-module.